### PR TITLE
Remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,6 @@
     "test:coverage": "npm run test -- --coverage",
     "test:coverage:deploy": "npm run test:coverage && codecov"
   },
-  "peerDependencies": {
-    "expo-camera": ">= 6.0.0",
-    "react-native": ">= 0.57.0",
-    "react-native-camera": ">= 2.6.0"
-  },
   "devDependencies": {
     "@babel/cli": "^7.12.10",
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
These are automatically installed in npm 7, and it seems unlikely that someone would like to install both expo-camera and react-native-camera in their project.