### PR TITLE
🚨 Fix tsc compiler warnings

### DIFF
--- a/src/recordVideo.ts
+++ b/src/recordVideo.ts
@@ -36,4 +36,5 @@ export const recordVideo = async (
   } else if (cameraRef && cameraRef.current && cameraRef.current.recordAsync) {
     return cameraRef.current.recordAsync(options);
   }
+  return undefined
 };

--- a/src/takePicture.ts
+++ b/src/takePicture.ts
@@ -46,4 +46,5 @@ export const takePicture = async (
   ) {
     return cameraRef.current.takePictureAsync(options);
   }
+  return undefined
 };


### PR DESCRIPTION
When running `tsc --noEmit`, those two functions generating errors:  error TS7030: Not all code paths return a value.